### PR TITLE
Fixed: System_Dashboard_Admin() -> PHP Warning:  Division by zero, PH…

### DIFF
--- a/admin/class-system-dashboard-admin.php
+++ b/admin/class-system-dashboard-admin.php
@@ -261,7 +261,10 @@ class System_Dashboard_Admin {
 
 		$tests_failed = ( $issue_counts['recommended'] * 0.5 ) + ( $issue_counts['critical'] * 1.5 );
 
-		$tests_score = 100 - ceil( ( $tests_failed / $tests_total ) * 100 );
+		$tests_score = 0;
+		if ( $tests_total > 0 ) {
+			$tests_score = 100 - ceil( ( $tests_failed / $tests_total ) * 100 );
+		}
 
 		if ( ( 80 <= $tests_score ) && ( 0 === (int) $issue_counts['critical'] ) ) {
 
@@ -1194,7 +1197,7 @@ class System_Dashboard_Admin {
 
 		}
 
-		return $cpu_core_count;		
+		return (int)$cpu_core_count;
 	}
 
 	/**
@@ -1207,7 +1210,7 @@ class System_Dashboard_Admin {
 
 		if ( $this->is_shell_exec_enabled() ) {
 
-			$cpu_core_count = $this-> sd_cpu_core_count();
+			$cpu_core_count = $this->sd_cpu_core_count();
 			$cpu_load_average = shell_exec("uptime");
 			$cpu_load_average_array = explode( ", ", $cpu_load_average );
 


### PR DESCRIPTION
Small fixes for:

PHP Warning:  Division by zero in /system-dashboard/admin/class-system-dashboard-admin.php on line 264
PHP Notice:  A non well formed numeric value encountered in /system-dashboard/admin/class-system-dashboard-admin.php on line 1218
PHP Notice:  A non well formed numeric value encountered in /system-dashboard/admin/class-system-dashboard-admin.php on line 1232
PHP Notice:  A non well formed numeric value encountered in /system-dashboard/admin/class-system-dashboard-admin.php on line 1248

Thanks.